### PR TITLE
Pin `tryexpand` dev-dependency to "=0.10.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 enumcapsulate-macros = { version = "0.6.3", path = "./macros", optional = true }
 
 [dev-dependencies]
-tryexpand = "0.10.0"
+tryexpand = "=0.10.0"
 
 [features]
 default = ["derive"]


### PR DESCRIPTION
(the last version to still support the MSRV, v1.78.0)